### PR TITLE
Issue with deployment API Version 'extensions/v1beta1'

### DIFF
--- a/example_deployment/02_deployment.yml
+++ b/example_deployment/02_deployment.yml
@@ -5,7 +5,7 @@ metadata:
   name: ecr-updater
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ecr-updater
   labels:


### PR DESCRIPTION
Got that error on the current example file:

```
kubectl apply -f 02_deployment.yml
serviceaccount/ecr-updater created
error: unable to recognize "02_deployment.yml": no matches for kind "Deployment" in version "extensions/v1beta1"
```