### PR TITLE
#10/add json logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .idea
 .vscode
+logging.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8-alpine
 RUN pip install pipenv
 WORKDIR /app
 COPY . .

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,9 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-boto3 = "*"
-kubernetes = "==3.0.*"
+boto3=">=1.17.0,<1.18"
+kubernetes=">=17.17.0,<18.0"
+python-json-logger="1.3.0"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "504f9a7b16ed53a527b016a176f512c1119fff33a64412f6fc0de6e4a318d146"
+            "sha256": "78907e5f7c826e129a92121284e01a662a1d573c63306b5db22ce6063b84c0d2"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -18,163 +18,223 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:10fd4bf8fe88f9bb449a538e639c1afb9762cb91693dea8c17282ba5c9d00b51",
-                "sha256:4d187262d30befec431b3b52ccce35e55c0062a86f19b9dd5328b18d6332c5aa"
+                "sha256:1d24c6d1f5db4b52bb29f1dfe13fd3e9d95d9fa4634b0638a096f5a884173cde",
+                "sha256:8ee8766813864796be6c87ad762c6da4bfef603977931854a38f49fe4db06495"
             ],
             "index": "pypi",
-            "version": "==1.9.151"
+            "version": "==1.17.84"
         },
         "botocore": {
             "hashes": [
-                "sha256:5e4774c106bb02f8e4639818c2f8157b8ec114a76e481e17cd3fe6955206e088",
-                "sha256:cfc667e7888aad09ead8f7e32129ea90aa5c7f602531094954bf6305db74aac4"
+                "sha256:75e1397b80aa8757a26636b949eebd20b3cf67e8f1ed80dc01170907e06ea45d",
+                "sha256:bc59eb748fcb07835613ebea6dcc2600ae1a8be0fae30e40b9c1e81b73262296"
             ],
-            "version": "==1.12.151"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.20.84"
         },
         "cachetools": {
             "hashes": [
-                "sha256:219b7dc6024195b6f2bc3d3f884d1fef458745cd323b04165378622dcc823852",
-                "sha256:9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460"
+                "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001",
+                "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"
             ],
-            "version": "==3.1.0"
+            "markers": "python_version ~= '3.5'",
+            "version": "==4.2.2"
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2019.3.9"
+            "version": "==2021.5.30"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
-        },
-        "docutils": {
-            "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
-            ],
-            "version": "==0.14"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4",
-                "sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed"
+                "sha256:044d81b1e58012f8ebc71cc134e191c1fa312f543f1fbc99973afe28c25e3228",
+                "sha256:b3ca7a8ff9ab3bdefee3ad5aefb11fc6485423767eee016f5942d8e606ca23fb"
             ],
-            "version": "==1.6.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.30.1"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
-        },
-        "ipaddress": {
-            "hashes": [
-                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
-                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
-            ],
-            "version": "==1.0.22"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "jmespath": {
             "hashes": [
-                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
-                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "version": "==0.9.4"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.0"
         },
         "kubernetes": {
             "hashes": [
-                "sha256:0a36f9777df218c959e8d75c0cd837ea3f3b67d86d96d90759c972a2b03b5633",
-                "sha256:42250263103d6e96e15f05f2a02a97571ade2843269ad602b1003159d8412671"
+                "sha256:225a95a0aadbd5b645ab389d941a7980db8cdad2a776fde64d1b43fc3299bde9",
+                "sha256:c69b318696ba797dcf63eb928a8d4370c52319f4140023c502d7dfdf2080eb79"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==17.17.0"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.1.0"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
-                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
-            "version": "==0.4.5"
+            "version": "==0.4.8"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:ef721f68f7951fab9b0404d42590f479e30d9005daccb1699b0a51bb4177db96",
-                "sha256:f309b6c94724aeaf7ca583feb1cc70430e10d7551de5e36edfc1ae6909bcfb3c"
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
+                "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
             ],
-            "version": "==0.2.5"
+            "version": "==0.2.8"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7'",
-            "version": "==2.8.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
+        "python-json-logger": {
+            "hashes": [
+                "sha256:f26eea7898db40609563bed0a7ca11af12e2a79858632706d835a0f961b7d398"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
-                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
-                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
-                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
-                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
-                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
-                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
-                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
-                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
-                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
-                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
             ],
-            "version": "==5.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
+        },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d",
+                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a",
+                "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"
+            ],
+            "version": "==1.3.0"
         },
         "rsa": {
             "hashes": [
-                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
-                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+                "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
+                "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
             ],
-            "version": "==4.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==4.7.2"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
-                "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
+                "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc",
+                "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"
             ],
-            "version": "==0.2.0"
+            "version": "==0.4.2"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "version": "==1.12.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
+                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
             ],
-            "markers": "python_version >= '3.4'",
-            "version": "==1.24.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.5"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:40ac14a0c54e14d22809a5c8d553de5a2ae45de3c60105fae53bcb281b3fe6fb"
+                "sha256:3e2bf58191d4619b161389a95bdce84ce9e0b24eb8107e7e590db682c2d0ca81",
+                "sha256:abf306dc6351dcef07f4d40453037e51cc5d9da2ef60d0fc5d0fe3bcda255372"
             ],
-            "version": "==0.40.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.1"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -45,3 +45,34 @@ Make sure to set your correct aws region in `example_deployment/02_deployment.ym
 
 5. Test a deployment. Replace the containerimage with one from your own ecr registry, deploy it and prosper! (note that the ecrupdater initially pauses for 60 seconds, so make sure time has passed between the ecr updater pod coming online, and you run the next command)
 `kubectl apply -f example_deployment/03_pullsecret_test.yml`
+
+## Logging
+By default, the service logs using the built in python logging package and the python-json-logger package for the json formatting.
+In order to change the log configuration, the service expects a log config file 'logging.json' in the working directory.
+Alternatively, this log config file path can be configured via the ENV variable `LOG_CONFIG_PATH` using a configMap.
+
+example log config file -> logging.json
+```
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "json": {
+      "format": "%(asctime)s %(levelname)s %(message)s %(pathname)s %(lineno)d %(threadName)s",
+      "class": "pythonjsonlogger.jsonlogger.JsonFormatter"
+    }
+  },
+  "handlers": {
+    "json": {
+      "class": "logging.StreamHandler",
+      "formatter": "json"
+    }
+  },
+  "loggers": {
+    "": {
+      "handlers": ["json"],
+      "level": "INFO"
+    }
+  }
+}
+``` 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ ECR_CREATE_MISSING: if this envvar is set to `true`, missing pull secrets will b
 (there's a good chance this will fail on older (pre 1.11) clusters.   
 AWS_DEFAULT_REGION: (set to your region)   
 AWS_ACCESS_KEY_ID: aws creds   
-AWS_SECRET_ACCESS_KEY: aws creds   
+AWS_SECRET_ACCESS_KEY: aws creds
+LOG_CONFIG: optional log config file (defaults to ./logging.json)   
+LOG_LEVEL: Applies only if no log config file has been found (defaults to INFO)   
 ```
 
 Note that if you're using alternate methods of providing the pod with AWS credentials (such as kube2iam or similar) you can skip the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` configuration items.
@@ -49,9 +51,12 @@ Make sure to set your correct aws region in `example_deployment/02_deployment.ym
 ## Logging
 By default, the service logs using the built in python logging package and the python-json-logger package for the json formatting.
 In order to change the log configuration, the service expects a log config file 'logging.json' in the working directory.
-Alternatively, this log config file path can be configured via the ENV variable `LOG_CONFIG_PATH` using a configMap.
+Alternatively, this log config file path can be configured via the ENV variable `LOG_CONFIG` using a configMap.
 
-example log config file -> logging.json
+### Logger config docs
+* https://docs.python.org/3/library/logging.config.html
+
+example log config file to enable JSON logging on INFO level.
 ```
 {
   "version": 1,

--- a/ecrupdater.py
+++ b/ecrupdater.py
@@ -4,13 +4,29 @@ import json
 import time
 import base64
 import boto3
+import logging
+import logging.config
 from kubernetes import client as k8sclient
 from kubernetes.client import Configuration, ApiClient
 
 
+def setup_logging(
+        log_config_path=os.environ.get('LOG_CONFIG_PATH', 'logging.json'),
+        default_level=logging.INFO,
+):
+    if os.path.exists(log_config_path):
+        print("Loading log configuration file from path '{}'...".format(log_config_path))
+        with open(log_config_path, 'rt') as f:
+            config = json.load(f)
+        logging.config.dictConfig(config)
+    else:
+        print("Loading default configuration.")
+        logging.basicConfig(level=default_level)
+
+
 def exception_handler(exception_type, exception, traceback):
     # Removes standard python stacktrace in case of exceptions
-    print("%s: %s" % (exception_type.__name__, exception))
+    logger.warning("%s: %s", exception_type.__name__, exception)
 
 
 # Custom exception hook to hide traceback info from logs
@@ -18,10 +34,11 @@ if not os.getenv('CDV2_DEBUG_ENABLED') == 'TRUE':
     sys.excepthook = exception_handler
 
 
-print('starting the thing')
+print('Starting ECR-updater ..')
 pull_secret_name = os.getenv('K8S_PULL_SECRET_NAME', None)
 env_update_interval = os.getenv('ECR_UPDATE_INTERVAL', '3600')
 create_missing_pull_secrets_str = os.getenv('ECR_CREATE_MISSING', 'false')
+# Allows the kubernetes python clients to talk to k8s via the kubectl-proxy sidecar container
 kubernetes_api_endpoint = os.getenv('KUBERNETES_API_ENDPOINT', 'localhost:8001')
 
 try:
@@ -66,15 +83,15 @@ def create_pull_secrets():
                 },
                 'type': 'kubernetes.io/dockerconfigjson'
             }
-            print(f'Creating secret {pull_secret_name} in namespace {namespace.metadata.name}')
+            logger.info('Creating secret "%s" in namespace "%s"', pull_secret_name, namespace.metadata.name)
             try:
                 v1.create_namespaced_secret(namespace.metadata.name, secret_body)
-            except Exception as e:
-                print(str(e))
+            except Exception:
+                logger.exception('Could not create secret "%s" in namespace "%s"', pull_secret_name, namespace.metadata.name)
 
 
 def update_ecr():
-    print('starting update loop')
+    logger.info('Starting ECR secret update loop ..')
     client = boto3.client('ecr')
     response = client.get_authorization_token()
     token = response['authorizationData'][0]['authorizationToken']
@@ -86,17 +103,16 @@ def update_ecr():
 
     k8s_config = Configuration()
     k8s_config.host = kubernetes_api_endpoint
-    k8s_api_client = ApiClient(config=k8s_config)
+    k8s_api_client = ApiClient(configuration=k8s_config)
     v1 = k8sclient.CoreV1Api(api_client=k8s_api_client)
     secrets = v1.list_secret_for_all_namespaces()
 
     registry_secrets = [x for x in secrets.items if x.metadata.name == pull_secret_name]
-    print(f'pull secret name to search for: {pull_secret_name}')
-    print(f'found {len(registry_secrets)} registry_secrets matching name {pull_secret_name}')
+    logger.info('Found %s registry_secrets matching name "%s"', len(registry_secrets), pull_secret_name)
     for secret in registry_secrets:
         secret_name = secret.metadata.name
         if secret.type == 'kubernetes.io/dockercfg':
-            print(f'Updating secret {secret_name} (type kubernetes.io/dockercfg) in namespace {secret.metadata.namespace}')
+            logger.info('Updating secret "%s" (type kubernetes.io/dockercfg) in namespace "%s"', secret_name, secret.metadata.namespace)
             k8s_secret = {
                 server:
                     {
@@ -120,7 +136,7 @@ def update_ecr():
             }
             res = v1.patch_namespaced_secret(secret.metadata.name, secret.metadata.namespace, body)
         elif secret.type == 'kubernetes.io/dockerconfigjson':
-            print(f'Updating secret {secret_name} (type kubernetes.io/dockerconfigjson) in namespace {secret.metadata.namespace}')
+            logger.info('Updating secret "%s" (type kubernetes.io/dockerconfigjson) in namespace "%s"', secret_name, secret.metadata.namespace)
             k8s_secret = {
                 'auths': {
                     bare_server: {
@@ -144,13 +160,15 @@ def update_ecr():
             }
             res = v1.patch_namespaced_secret(secret.metadata.name, secret.metadata.namespace, body)
         else:
-            print('Unknown secret type for secret {}: {}'.format(secret_name, secret.type))
+            logger.warning('Unknown secret type for secret name "%s": %s'.format(secret_name, secret.type))
 
 
 if __name__ == '__main__':
+    setup_logging()
+    logger = logging.getLogger(__name__)
     while True:
-        print('Running update loop')
+        logger.info('Running credentials update loop ..')
         create_pull_secrets()
         update_ecr()
-        print(f'...done. Waiting {str(update_interval)} seconds')
+        logger.info(f'...done. Waiting %s seconds', update_interval)
         time.sleep(update_interval)

--- a/example_deployment/02_deployment.yml
+++ b/example_deployment/02_deployment.yml
@@ -4,6 +4,35 @@ kind: ServiceAccount
 metadata:
   name: ecr-updater
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: log-configuration
+data:
+  logging.json: |
+    {
+      "version": 1,
+      "disable_existing_loggers": false,
+      "formatters": {
+        "json": {
+          "format": "%(asctime)s %(levelname)s %(message)s %(pathname)s %(lineno)d %(threadName)s",
+          "class": "pythonjsonlogger.jsonlogger.JsonFormatter"
+        }
+      },
+      "handlers": {
+        "json": {
+          "class": "logging.StreamHandler",
+          "formatter": "json"
+        }
+      },
+      "loggers": {
+        "": {
+          "handlers": [ "json" ],
+          "level": "INFO"
+        }
+      }
+    }
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -40,5 +69,14 @@ spec:
             secretKeyRef:
               name: ecr-aws-credentials
               key: AWS_SECRET_ACCESS_KEY
+        - name: LOG_CONFIG
+          value: /etc/log-configuration/logging.json
+        volumeMounts:
+        - mountPath: /etc/log-configuration
+          name: log-configuration
       - image: palmstonegames/kubectl-proxy
         name: kubectl-proxy
+      volumes:
+      - name: log-configuration
+        configMap:
+          name: log-configuration


### PR DESCRIPTION
This will present the logs as follows if configured as shown in the examples.
Otherwise it will fallback to stdout logging in default format. 

```
Starting ECR-updater ..
Loading log configuration file from path './logging.json'...
{"asctime": "2021-05-31 08:13:37,798", "levelname": "INFO", "message": "Running credentials update loop ..", "pathname": "ecrupdater.py", "lineno": 178, "threadName": "MainThread"}
{"asctime": "2021-05-31 08:13:37,798", "levelname": "INFO", "message": "Starting ECR secret update loop ..", "pathname": "ecrupdater.py", "lineno": 97, "threadName": "MainThread"}
{"asctime": "2021-05-31 08:13:38,892", "levelname": "WARNING", "message": "NoCredentialsError: Unable to locate credentials", "pathname": "ecrupdater.py", "lineno": 30, "threadName": "MainThread"}
```
This way the logs can easily be parsed on a log aggregator such as graylog or ELK.

AC
- [x] support optional json logging. Will modify the current stdout slightly.
- [x] bump python to 3.8
- [x] lock pypi dependencies 